### PR TITLE
fix: end break on time instead of waiting on a throttled alarm

### DIFF
--- a/extension/background.ts
+++ b/extension/background.ts
@@ -24,7 +24,53 @@ const CHIME_LIFETIME_MS = 2500;
 const NOTIF_CLEAR_ALARM = "flowmodoro:clear-notification";
 const NOTIF_ID = "flowmodoro-break-end";
 
-const clearAlarm = () => chrome.alarms.clear(BREAK_END_ALARM);
+// Wakes the worker shortly before the break ends so it can arm a precise timer.
+const BREAK_ARM_ALARM = "flowmodoro:break-arm";
+
+// Any extension API call resets Chrome's 30s service-worker idle timer; ping
+// comfortably inside that window.
+const KEEPALIVE_INTERVAL_MS = 20_000;
+
+// How early to wake. Must clear two floors: Chrome refuses to deliver alarms
+// less than ~30s out, and delivery itself runs late by a random 10-30s. 90s
+// leaves margin on both so the arm alarm always lands before the break ends.
+const ARM_LEAD_MS = 90_000;
+
+const clearAlarms = () =>
+  Promise.all([
+    chrome.alarms.clear(BREAK_END_ALARM),
+    chrome.alarms.clear(BREAK_ARM_ALARM),
+  ]);
+
+let keepaliveTimer: ReturnType<typeof setInterval> | null = null;
+let preciseTimer: ReturnType<typeof setTimeout> | null = null;
+let endingBreak = false;
+
+const stopBreakTimers = () => {
+  if (keepaliveTimer !== null) {
+    clearInterval(keepaliveTimer);
+    keepaliveTimer = null;
+  }
+  if (preciseTimer !== null) {
+    clearTimeout(preciseTimer);
+    preciseTimer = null;
+  }
+};
+
+// Hold the worker awake and end the break on a precise in-worker timeout.
+// Only used for the final stretch of a break — see scheduleBreakEnd.
+const startBreakTimers = (when: number) => {
+  stopBreakTimers();
+  keepaliveTimer = setInterval(() => {
+    chrome.runtime.getPlatformInfo().catch(() => {
+      // No-op: keepalive ping only exists for its side effect.
+    });
+  }, KEEPALIVE_INTERVAL_MS);
+  preciseTimer = setTimeout(() => {
+    preciseTimer = null;
+    endBreak();
+  }, Math.max(0, when - Date.now()));
+};
 
 const ICON_SETS = {
   idle: {
@@ -107,30 +153,59 @@ const scheduleBreakEnd = (snap: TimerSnapshot) => {
     snap.breakStartTime == null ||
     snap.breakDuration <= 0
   ) {
-    return clearAlarm();
+    stopBreakTimers();
+    return clearAlarms();
   }
   const when = snap.breakStartTime + snap.breakDuration * 1000;
   if (when <= Date.now()) {
+    stopBreakTimers();
     return endBreak();
   }
+  // Safety net for both paths below: if Chrome evicts the worker anyway (device
+  // sleep, memory pressure), the in-memory timers die with it and only this is
+  // left. Late, but never silent.
   chrome.alarms.create(BREAK_END_ALARM, { when });
+
+  // Keeping the worker awake costs memory, so only do it for the final stretch.
+  // Sleep through the rest of the break and let a cheap alarm wake us early —
+  // that alarm can be its usual tens-of-seconds late and still land in time,
+  // because ARM_LEAD_MS is budgeted for exactly that.
+  if (when - Date.now() > ARM_LEAD_MS) {
+    chrome.alarms.clear(BREAK_ARM_ALARM);
+    chrome.alarms.create(BREAK_ARM_ALARM, { when: when - ARM_LEAD_MS });
+    stopBreakTimers();
+    return;
+  }
+  // Inside the lead window — either a short break, or the arm alarm just woke
+  // us. Hold the worker and end on the precise timer.
+  chrome.alarms.clear(BREAK_ARM_ALARM);
+  startBreakTimers(when);
 };
 
 const endBreak = async () => {
-  const stored = await chrome.storage.local.get(STORAGE_KEY);
-  const snap = stored[STORAGE_KEY] as TimerSnapshot | undefined;
-  // Bail if break was already ended (e.g. via manual reset from the popup).
-  if (!snap || snap.status !== "breaking" || !snap.isRunning) return;
-  await chrome.storage.local.set({ [STORAGE_KEY]: { ...initialSnapshot } });
-  await playBreakEndSound();
-  chrome.notifications.create(NOTIF_ID, {
-    type: "basic",
-    iconUrl: "icons/icon-128.png",
-    title: "Break finished",
-    message: "Back to flow when you are ready.",
-    requireInteraction: false,
-  });
-  chrome.alarms.create(NOTIF_CLEAR_ALARM, { delayInMinutes: 0.1 });
+  // The precise timer and the safety-net alarm can both land; the storage check
+  // below only rejects the second one once the first has finished writing.
+  if (endingBreak) return;
+  endingBreak = true;
+  try {
+    const stored = await chrome.storage.local.get(STORAGE_KEY);
+    const snap = stored[STORAGE_KEY] as TimerSnapshot | undefined;
+    // Bail if break was already ended (e.g. via manual reset from the popup,
+    // or by an open popup ending it locally).
+    if (!snap || snap.status !== "breaking" || !snap.isRunning) return;
+    await chrome.storage.local.set({ [STORAGE_KEY]: { ...initialSnapshot } });
+    await playBreakEndSound();
+    chrome.notifications.create(NOTIF_ID, {
+      type: "basic",
+      iconUrl: "icons/icon-128.png",
+      title: "Break finished",
+      message: "Back to flow when you are ready.",
+      requireInteraction: false,
+    });
+    chrome.alarms.create(NOTIF_CLEAR_ALARM, { delayInMinutes: 0.1 });
+  } finally {
+    endingBreak = false;
+  }
 };
 
 chrome.runtime.onInstalled.addListener(async () => {
@@ -161,7 +236,26 @@ chrome.storage.onChanged.addListener((changes, area) => {
   applyAction(next);
 });
 
-chrome.alarms.onAlarm.addListener((alarm) => {
+chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (alarm.name === BREAK_END_ALARM) endBreak();
   if (alarm.name === NOTIF_CLEAR_ALARM) chrome.notifications.clear(NOTIF_ID);
+  if (alarm.name === BREAK_ARM_ALARM) {
+    // Re-read rather than trusting the alarm: the break may have been reset or
+    // restarted while we slept. scheduleBreakEnd decides what this snapshot
+    // now needs — usually arming the precise timer for the final stretch.
+    const stored = await chrome.storage.local.get(STORAGE_KEY);
+    scheduleBreakEnd(
+      (stored[STORAGE_KEY] as TimerSnapshot | undefined) ?? initialSnapshot
+    );
+  }
+});
+
+// The keepalive and precise timer live in worker memory, so they die with the
+// worker. Top-level code runs on every worker start, so re-arm from the
+// persisted snapshot on whatever wakes us — not just install/startup.
+chrome.storage.local.get(STORAGE_KEY).then((stored) => {
+  const snap =
+    (stored[STORAGE_KEY] as TimerSnapshot | undefined) ?? initialSnapshot;
+  scheduleBreakEnd(snap);
+  applyAction(snap);
 });

--- a/src/hooks/use-timer.ts
+++ b/src/hooks/use-timer.ts
@@ -130,15 +130,14 @@ export const useTimer = (): TimerApi => {
         const remaining = computeBreakRemaining(snap, now);
         setBreakTime(remaining);
         if (remaining <= 0) {
-          if (!getChrome()) {
-            // Single-page (no service worker): play sound and reset locally.
-            playNotificationSound();
-            commit({ ...initialSnapshot });
-          }
-          // Extension: defer to the background alarm so the chime plays via
-          // the offscreen document regardless of whether the popup is open,
-          // and a manual reset (which also writes initial) cannot be mistaken
-          // for a natural end.
+          // End the break here whenever this page is alive to see it happen —
+          // single-page and open popup alike. chrome.alarms delivery is coarse
+          // for packed extensions (seconds to tens of seconds, non-deterministic),
+          // so waiting on the background alarm made an open popup sit visibly
+          // past zero. Writing the snapshot flips the UI immediately and the
+          // background clears the pending alarm when it sees the change.
+          playNotificationSound();
+          commit({ ...initialSnapshot });
         }
       }
     };


### PR DESCRIPTION
## Problem

Break end was driven entirely by a `chrome.alarms` alarm waking a dormant service worker. Chrome delivers alarms lazily for packed extensions, so the installed build lagged **~8s with the popup open** and **~25s with it closed**, at random.

Unpacked dev builds hid this completely: unpacked extensions have no alarm rate limit, and keeping the service-worker inspector open prevents the worker from ever sleeping.

## Changes

**Popup** (`src/hooks/use-timer.ts`) — end the break locally whenever the page is alive to see it, instead of deferring to the alarm. The tick loop already computed `remaining <= 0` every second and did nothing with it. `endBreak()` re-reads storage and bails when the snapshot is no longer `breaking`, so the pending alarm can't double-fire the chime.

**Background** (`extension/background.ts`) — sleep through most of the break, then wake early via a new arm alarm 90s before the end. That alarm can be its usual tens of seconds late and still land in time. Once awake, hold the worker with a 20s keepalive ping and end on a precise `setTimeout`.

- The end alarm stays as a safety net for genuine eviction (device sleep, memory pressure)
- Re-arm from storage at top level, since in-memory timers die with the worker and it may be woken by something other than install/startup
- `endBreak()` gained a re-entry guard: the precise timer and the alarm can now race, and the storage check alone only rejects the second caller after the first has finished writing

Keepalive runs ~90s per break instead of the full duration, so a 20-minute break holds the worker for ~7% of the time a naive keepalive would.

## Not verified

**This has not been run.** Typechecks and builds clean; that's all. The timing claims are reasoned from Chrome's documented behavior plus one user's measurements, not observed.

Two-stage testing needed, because **unpacked testing cannot reproduce the bug** — no alarm rate limit applies there:

1. **Unpacked** — logic check: worker sleeps mid-break, wakes ~90s early, chime plays, UI flips, no double chime
2. **Packed via trusted testers** — timing check: real throttling only happens on a store install

## Behavior change

When the popup is open, the OS notification no longer appears — the popup plays the chime and flips instantly, and the background bails. Deliberate (a system notification while you're looking at the popup is noise), but visible to existing users.

## Known limits

Unchanged by this fix: device sleep mid-break still evicts the worker (chime arrives on wake), and Chrome fully closed still fires nothing. The keepalive is also a workaround rather than a supported API — if Chrome closes it, behavior degrades back to current lag rather than breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)